### PR TITLE
Fix WASM wildcard rules handling issue

### DIFF
--- a/src/rulesets.rs
+++ b/src/rulesets.rs
@@ -451,6 +451,8 @@ pub mod tests {
         let mut rs = RuleSets::new();
         add_mock_rulesets(&mut rs);
 
+        assert_eq!(rs.potentially_applicable(&String::from("foo.1fichier.com")).len(), 1);
+        assert_eq!(rs.potentially_applicable(&String::from("bar.foo.1fichier.com")).len(), 1);
         assert_eq!(rs.potentially_applicable(&String::from("foo.storage.googleapis.com")).len(), 1);
         assert_eq!(rs.potentially_applicable(&String::from("bar.foo.storage.googleapis.com")).len(), 1);
     }

--- a/src/rulesets.rs
+++ b/src/rulesets.rs
@@ -452,6 +452,7 @@ pub mod tests {
         add_mock_rulesets(&mut rs);
 
         assert_eq!(rs.potentially_applicable(&String::from("foo.storage.googleapis.com")).len(), 1);
+        assert_eq!(rs.potentially_applicable(&String::from("bar.foo.storage.googleapis.com")).len(), 1);
     }
 
     #[test]

--- a/src/rulesets.rs
+++ b/src/rulesets.rs
@@ -385,7 +385,7 @@ impl RuleSets {
 
         // now eat away from the left, with *, so that for x.y.z.google.com we
         // check *.y.z.google.com, *.z.google.com and *.google.com
-        for index in 0..(segmented.len() - 2) {
+        for index in 0..(segmented.len() - 1) {
             let mut segmented_tmp = segmented.clone();
             segmented_tmp[index] = "*";
             let tmp_host = &segmented_tmp[index..segmented.len()].join(".");

--- a/src/rulesets.rs
+++ b/src/rulesets.rs
@@ -388,7 +388,7 @@ impl RuleSets {
         for index in 0..(segmented.len() - 2) {
             let mut segmented_tmp = segmented.clone();
             segmented_tmp[index] = "*";
-            let tmp_host = &segmented_tmp[index,segmented.len()].join(".");
+            let tmp_host = &segmented_tmp[index..segmented.len()].join(".");
             self.try_add(&mut results, &tmp_host);
         }
 

--- a/src/rulesets.rs
+++ b/src/rulesets.rs
@@ -385,10 +385,10 @@ impl RuleSets {
 
         // now eat away from the left, with *, so that for x.y.z.google.com we
         // check *.y.z.google.com, *.z.google.com and *.google.com
-        for index in 0..(segmented.len() - 1) {
+        for index in 0..(segmented.len() - 2) {
             let mut segmented_tmp = segmented.clone();
             segmented_tmp[index] = "*";
-            let tmp_host = segmented_tmp.join(".");
+            let tmp_host = &segmented_tmp[index,segmented.len()].join(".");
             self.try_add(&mut results, &tmp_host);
         }
 


### PR DESCRIPTION
@Hainish A report https://github.com/EFForg/https-everywhere/issues/18589 suggests that the WASM module of HTTPS Everywhere does not support wildcard rules properly. Would you take a look at this PR?  

See also https://github.com/EFForg/https-everywhere/issues/18589