### PR TITLE
Prefer &str, &[T] over &String, &Vec<T>

### DIFF
--- a/src/rulesets.rs
+++ b/src/rulesets.rs
@@ -146,7 +146,7 @@ impl RuleSet {
     }
 
     #[cfg(feature="add_rulesets")]
-    pub(crate) fn add_rules(&mut self, rules: &Vec<Value>) {
+    pub(crate) fn add_rules(&mut self, rules: &[Value]) {
         for rule in rules {
             if let Value::Object(rule) = rule {
                 let from = match rule.get(JSON_STRINGS.from) {
@@ -163,7 +163,7 @@ impl RuleSet {
     }
 
     #[cfg(feature="add_rulesets")]
-    pub(crate) fn add_exclusions(&mut self, exclusions: &Vec<Value>) {
+    pub(crate) fn add_exclusions(&mut self, exclusions: &[Value]) {
         let mut exclusions_vec = vec![];
         for exclusion in exclusions {
             if let Value::String(exclusion) = exclusion {
@@ -175,7 +175,7 @@ impl RuleSet {
     }
 
     #[cfg(feature="add_rulesets")]
-    pub(crate) fn add_cookierules(&mut self, cookierules: &Vec<Value>) {
+    pub(crate) fn add_cookierules(&mut self, cookierules: &[Value]) {
         let mut cookierules_vec = vec![];
 
         for cookierule in cookierules {
@@ -262,7 +262,7 @@ impl RuleSets {
     /// * `scope` - An optional string which indicates the scope of the current batch of rulesets
     /// being added (see the [ruleset update channels](https://github.com/EFForg/https-everywhere/blob/master/docs/en_US/ruleset-update-channels.md) documentation)
     #[cfg(feature="add_rulesets")]
-    pub fn add_all_from_json_string(&mut self, json_string: &String, enable_mixed_rulesets: &bool, ruleset_active_states: &HashMap<String, bool>, scope: &Option<String>) {
+    pub fn add_all_from_json_string(&mut self, json_string: &str, enable_mixed_rulesets: &bool, ruleset_active_states: &HashMap<String, bool>, scope: &Option<String>) {
         let rulesets: Value = serde_json::from_str(&json_string).expect(ERROR_SERDE_PARSE);
         self.add_all_from_serde_value(rulesets, enable_mixed_rulesets, ruleset_active_states, scope);
     }
@@ -362,7 +362,7 @@ impl RuleSets {
     ///
     /// * `host` - A string which indicates the host to search for potentially applicable rulesets
     #[cfg(feature="potentially_applicable")]
-    pub fn potentially_applicable(&self, host: &String) -> Vec<Arc<RuleSet>> {
+    pub fn potentially_applicable(&self, host: &str) -> Vec<Arc<RuleSet>> {
         let mut results = vec![];
 
         self.try_add(&mut results, host);
@@ -398,7 +398,7 @@ impl RuleSets {
     }
 
     #[cfg(feature="potentially_applicable")]
-    fn try_add(&self, results: &mut Vec<Arc<RuleSet>>, host: &String) {
+    fn try_add(&self, results: &mut Vec<Arc<RuleSet>>, host: &str) {
         if self.0.contains_key(host) {
             if let Some(rulesets) = self.0.get(host) {
                 for ruleset in rulesets {
@@ -444,7 +444,7 @@ pub mod tests {
         let mut rs = RuleSets::new();
         add_mock_rulesets(&mut rs);
 
-        assert_eq!(rs.potentially_applicable(&String::from("1fichier.com")).len(), 1);
+        assert_eq!(rs.potentially_applicable("1fichier.com").len(), 1);
     }
 
     #[test]
@@ -453,10 +453,10 @@ pub mod tests {
         let mut rs = RuleSets::new();
         add_mock_rulesets(&mut rs);
 
-        assert_eq!(rs.potentially_applicable(&String::from("foo.1fichier.com")).len(), 1);
-        assert_eq!(rs.potentially_applicable(&String::from("bar.foo.1fichier.com")).len(), 1);
-        assert_eq!(rs.potentially_applicable(&String::from("foo.storage.googleapis.com")).len(), 1);
-        assert_eq!(rs.potentially_applicable(&String::from("bar.foo.storage.googleapis.com")).len(), 1);
+        assert_eq!(rs.potentially_applicable("foo.1fichier.com").len(), 1);
+        assert_eq!(rs.potentially_applicable("bar.foo.1fichier.com").len(), 1);
+        assert_eq!(rs.potentially_applicable("foo.storage.googleapis.com").len(), 1);
+        assert_eq!(rs.potentially_applicable("bar.foo.storage.googleapis.com").len(), 1);
     }
 
     #[test]
@@ -465,7 +465,7 @@ pub mod tests {
         let mut rs = RuleSets::new();
         add_mock_rulesets(&mut rs);
 
-        assert_eq!(rs.potentially_applicable(&String::from("nonmatch.example.com")).len(), 0);
+        assert_eq!(rs.potentially_applicable("nonmatch.example.com").len(), 0);
     }
 
     #[test]

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -323,7 +323,7 @@ mod tests {
         assert_eq!(rs2.lock().unwrap().count_targets(), 0);
 
         let update_channels_string = fs::read_to_string("tests/update_channels.json").unwrap();
-        let ucs = UpdateChannels::from(&update_channels_string);
+        let ucs = UpdateChannels::from(&update_channels_string[..]);
 
         let mut updater = Updater::new(rs, &ucs, s, None, 15);
         updater.perform_check();
@@ -340,7 +340,7 @@ mod tests {
         let rs = Arc::new(Mutex::new(rs));
 
         let update_channels_string = fs::read_to_string("tests/update_channels.json").unwrap();
-        let ucs = UpdateChannels::from(&update_channels_string);
+        let ucs = UpdateChannels::from(&update_channels_string[..]);
 
         let t = thread::spawn(move || {
             let updater = Updater::new(rs, &ucs, s, None, 15);

--- a/src/updater/update_channels.rs
+++ b/src/updater/update_channels.rs
@@ -31,7 +31,7 @@ pub struct UpdateChannel {
     pub replaces_default_rulesets: bool,
 }
 
-impl From<&String> for UpdateChannel {
+impl From<&str> for UpdateChannel {
     /// Returns an update channel given a JSON string
     ///
     /// # Arguments
@@ -43,7 +43,7 @@ impl From<&String> for UpdateChannel {
     ///
     /// Panics if a name, update path prefix, or pem is not specified, if the pem file does not
     /// parse correctly into an RSA key, or it is not an object
-    fn from(json_string: &String) -> UpdateChannel {
+    fn from(json_string: &str) -> UpdateChannel {
         let update_channel: Value = serde_json::from_str(&json_string).expect(ERROR_SERDE_PARSE);
         UpdateChannel::from(&update_channel)
     }
@@ -52,7 +52,7 @@ impl From<&String> for UpdateChannel {
 impl From<&Value> for UpdateChannel {
     /// Returns an update channel given a serde_json::Value
     ///
-    /// See the implementation of `From<&String>` for more detail
+    /// See the implementation of `From<&str>` for more detail
     fn from(json_value: &Value) -> UpdateChannel {
         if let Value::Object(update_channel) = json_value {
             let name = match update_channel.get(JSON_STRINGS.name) {
@@ -113,13 +113,13 @@ impl UpdateChannels {
 
 /// Returns update channels given a JSON string
 ///
-/// See the implementation of `From<&String> for UpdateChannel` for more detail
+/// See the implementation of `From<&str> for UpdateChannel` for more detail
 ///
 /// # Panics
 ///
 /// Panics if the update channels JSON is not an array
-impl From<&String> for UpdateChannels {
-    fn from(json_string: &String) -> UpdateChannels {
+impl From<&str> for UpdateChannels {
+    fn from(json_string: &str) -> UpdateChannels {
         if let Value::Array(update_channels) = serde_json::from_str(&json_string).expect(ERROR_SERDE_PARSE) {
             UpdateChannels(update_channels.into_iter().map(|uc| {
                 UpdateChannel::from(&uc)
@@ -140,7 +140,7 @@ mod tests {
     }
 
     fn create_mock_update_channels() -> UpdateChannels {
-        UpdateChannels::from(&mock_update_channels_json())
+        UpdateChannels::from(&mock_update_channels_json()[..])
     }
 
     #[test]


### PR DESCRIPTION
`&str` is preferred over `&String` in function parameters whenever possible to improve ergonomics and avoid heap allocations. Same logic applies for `&[T]` vs. `&Vec<T>`.

ref: https://rust-lang.github.io/rust-clippy/master/#ptr_arg